### PR TITLE
In Vm.CheckVmWithoutError, wrap exceptions in ShovelException before rethrowing them.

### DIFF
--- a/csharp/NShovel/.editorconfig
+++ b/csharp/NShovel/.editorconfig
@@ -1,0 +1,6 @@
+root = true
+
+[*]
+end_of_line = CRLF
+indent_style = space
+indent_size = 4

--- a/csharp/NShovel/Shovel/Exceptions/ShovelException.cs
+++ b/csharp/NShovel/Shovel/Exceptions/ShovelException.cs
@@ -27,6 +27,9 @@ namespace Shovel.Exceptions
 {
     public class ShovelException : Exception
     {
+        public ShovelException() {}
+        public ShovelException( string message, Exception innerException ) : base( message, innerException ) { }
+
         public string FileName { get; set; }
 
         public override string Message { 

--- a/csharp/NShovel/Shovel/Vm/Vm.cs
+++ b/csharp/NShovel/Shovel/Vm/Vm.cs
@@ -1552,10 +1552,10 @@ namespace Shovel.Vm
         void CheckVmWithoutError ()
         {
             if (this.userDefinedPrimitiveError != null) {
-                throw this.userDefinedPrimitiveError;
+                throw new ShovelException( "An exception has been thrown in a user-defined primitive.", this.userDefinedPrimitiveError );
             }
             if (this.programmingError != null) {
-                throw this.programmingError;
+                throw new ShovelException( "An exception has occurred in the Shovel program.", this.programmingError );
             }
         }
 


### PR DESCRIPTION
When a previously caught exception is rethrown, its call stack is replaced by the call stack of the rethrowing point, thus irrevocably losing the original call stack.
Wrapping in another exception (through the InnerException property) preserves the stack.
