### PR TITLE
Open certain data structures to allow GC walking from roots to all reachable values

### DIFF
--- a/csharp/NShovel/Shovel/Api.cs
+++ b/csharp/NShovel/Shovel/Api.cs
@@ -26,6 +26,8 @@ using System.IO;
 using System.Linq;
 using System.Security.Cryptography;
 using Shovel.Exceptions;
+using Shovel.Vm.Types;
+using Shovel.Vm;
 
 namespace Shovel
 {
@@ -214,6 +216,14 @@ namespace Shovel
             return vm.CheckStackTop ();
         }
 
+        public static IEnumerable<Value> GetUsedStack( Vm.Vm vm ) {
+            return vm.GetUsedStack();
+        }
+
+        public static VmEnvironment GetCurrentEnvironment( Vm.Vm vm ) { 
+            return vm.GetCurrentEnvironment(); 
+        }
+
         public static void WakeUpVm (Vm.Vm vm)
         {
             vm.WakeUp ();
@@ -253,7 +263,7 @@ namespace Shovel
         {
             for (int i = 0; i < str.Struct.Fields.Length; i++) {
                 if (str.Struct.Fields[i] == key) {
-                    return str.Values[i];
+                    return str.values[i];
                 }
             }
             return defaultValue;
@@ -263,7 +273,7 @@ namespace Shovel
         {
             for (int i = 0; i < str.Struct.Fields.Length; i++) {
                 if (str.Struct.Fields[i] == key) {
-                    str.Values[i] = newValue;
+                    str.values[i] = newValue;
                     return true;
                 }
             }

--- a/csharp/NShovel/Shovel/Callable.cs
+++ b/csharp/NShovel/Shovel/Callable.cs
@@ -41,7 +41,7 @@ namespace Shovel
         // The next two fields are only used if this is a ShovelScript closure.
         internal int? ProgramCounter { get; set; }
 
-        internal Vm.Types.VmEnvironment Environment { get; set; }
+        public Vm.VmEnvironment Environment { get; internal set; }
 
         internal Func<VmApi, Value[], int, int, Value> RequiredPrimitive { get; set; }
 
@@ -96,7 +96,5 @@ namespace Shovel
         {
             return (vmapi, args, start, length) => callable (vmapi, args [start], args [start + 1], args [start + 2]);
         }
-
     }
 }
-

--- a/csharp/NShovel/Shovel/Serialization/VmStateSerializer.cs
+++ b/csharp/NShovel/Shovel/Serialization/VmStateSerializer.cs
@@ -25,6 +25,7 @@ using System.IO;
 using Shovel.Vm.Types;
 using System.Text;
 using System.Linq;
+using Shovel.Vm;
 
 namespace Shovel.Serialization
 {
@@ -433,8 +434,8 @@ namespace Shovel.Serialization
             var result = new VmEnvFrame ();
             objects [index] = result;
 
-            result.VarNames = (string[])reader (composite.Elements [0]);
-            result.Values = (Value[])reader (composite.Elements [1]);
+            result.VarNamesInternal = (string[])reader (composite.Elements [0]);
+            result.ValuesInernal = (Value[])reader (composite.Elements [1]);
             result.IntroducedAtProgramCounter = (int)(long)reader (composite.Elements [2]);
 
             return result;
@@ -457,7 +458,7 @@ namespace Shovel.Serialization
             objects [index] = result;
 
             result.Struct = (Struct)reader (composite.Elements [0]);
-            result.Values = (Value[])reader (composite.Elements [1]);
+            result.values = (Value[])reader (composite.Elements [1]);
 
             return result;
         }
@@ -670,8 +671,8 @@ namespace Shovel.Serialization
                 Elements = new int[3] 
             };
             var result = SerializeOneHashed (composite, obj);
-            composite.Elements [0] = Serialize (frame.VarNames);
-            composite.Elements [1] = Serialize (frame.Values);
+            composite.Elements [0] = Serialize (frame.VarNamesInternal);
+            composite.Elements [1] = Serialize (frame.ValuesInernal);
             composite.Elements [2] = SerializeOne (frame.IntroducedAtProgramCounter);
             return result;
         }
@@ -695,7 +696,7 @@ namespace Shovel.Serialization
             };
             var result = SerializeOneHashed (composite, obj);
             composite.Elements [0] = Serialize (structInstance.Struct);
-            composite.Elements [1] = SerializeShovelValueArray (structInstance.Values);
+            composite.Elements [1] = SerializeShovelValueArray (structInstance.values);
             return result;
         }
 
@@ -717,15 +718,15 @@ namespace Shovel.Serialization
             case Value.Kinds.Hash:
                 return SerializeHash (sv.hashValue, obj);
             case Value.Kinds.Callable:
-                return SerializeCallable (sv.CallableValue, obj);
+                return SerializeCallable (sv.callableValue, obj);
             case Value.Kinds.ReturnAddress:
-                return SerializeReturnAddress (sv.ReturnAddressValue, obj);
+                return SerializeReturnAddress (sv.returnAddressValue, obj);
             case Value.Kinds.NamedBlock:
-                return SerializeNamedBlock (sv.NamedBlockValue, obj);
+                return SerializeNamedBlock (sv.namedBlockValue, obj);
             case Value.Kinds.Struct:
                 return SerializeStruct (sv.StructValue, obj);
             case Value.Kinds.StructInstance:
-                return SerializeStructInstance (sv.StructInstanceValue, obj);
+                return SerializeStructInstance (sv.structInstanceValue, obj);
             default:
                 Shovel.Utils.Panic ();
                 throw new InvalidOperationException ();

--- a/csharp/NShovel/Shovel/StructInstance.cs
+++ b/csharp/NShovel/Shovel/StructInstance.cs
@@ -1,11 +1,14 @@
 using System;
+using System.Collections.Generic;
 
 namespace Shovel
 {
     public class StructInstance
     {
         internal Struct Struct;
-        internal Value[] Values;
+        internal Value[] values;
+
+        public IEnumerable<Value> Values { get { return values; } }
     }
 }
 

--- a/csharp/NShovel/Shovel/Value.cs
+++ b/csharp/NShovel/Shovel/Value.cs
@@ -226,15 +226,63 @@ namespace Shovel
         }
 
         [FieldOffset(8)]
-        internal Callable CallableValue;
+        internal Callable callableValue;
+
+        public Either<Callable> CallableValue {
+            get {
+                if ( Kind == Kinds.Callable ) {
+                    return new Either<Callable>( this.callableValue );
+                }
+                else {
+                    return new Either<Callable>( new ShovelException( "Value is not a callable.", null ) );
+                }
+            }
+        }
+
         [FieldOffset(8)]
-        internal ReturnAddress ReturnAddressValue;
+        internal StructInstance structInstanceValue;
+
+        public Either<StructInstance> StructInstanceValue {
+            get {
+                if ( Kind == Kinds.StructInstance ) {
+                    return new Either<StructInstance>( this.structInstanceValue );
+                }
+                else {
+                    return new Either<StructInstance>( new ShovelException( "Value is not a struct instance.", null ) );
+                }
+            }
+        }
+
+        [FieldOffset( 8 )]
+        internal NamedBlock namedBlockValue;
+
+        public Either<NamedBlock> NamedBlockValue {
+            get {
+                if ( Kind == Kinds.NamedBlock ) {
+                    return new Either<NamedBlock>( this.namedBlockValue );
+                }
+                else {
+                    return new Either<NamedBlock>( new ShovelException( "Value is not a named block.", null ) );
+                }
+            }
+        }
+
         [FieldOffset(8)]
-        internal NamedBlock NamedBlockValue;
+        internal ReturnAddress returnAddressValue;
+
+        public Either<ReturnAddress> ReturnAddressValue {
+            get {
+                if ( Kind == Kinds.ReturnAddress ) {
+                    return new Either<ReturnAddress>( this.returnAddressValue );
+                }
+                else {
+                    return new Either<ReturnAddress>( new ShovelException( "Value is not a return address.", null ) );
+                }
+            }
+        }
+
         [FieldOffset(8)]
         internal Struct StructValue;
-        [FieldOffset(8)]
-        public StructInstance StructInstanceValue;
 
         static Value value;
 
@@ -255,7 +303,7 @@ namespace Shovel
         {
             Value result = value;
             result.Kind = Kinds.StructInstance;
-            result.StructInstanceValue = structInstance;
+            result.structInstanceValue = structInstance;
             return result;
         }
 
@@ -320,7 +368,7 @@ namespace Shovel
         {
             Value result = value;
             result.Kind = Kinds.Callable;
-            result.CallableValue = c;
+            result.callableValue = c;
             return result;
         }
 
@@ -328,7 +376,7 @@ namespace Shovel
         {
             Value result = value;
             result.Kind = Kinds.ReturnAddress;
-            result.ReturnAddressValue = ra;
+            result.returnAddressValue = ra;
             return result;
         }
 
@@ -336,7 +384,7 @@ namespace Shovel
         {
             Value result = value;
             result.Kind = Kinds.NamedBlock;
-            result.NamedBlockValue = nb;
+            result.namedBlockValue = nb;
             return result;
         }
 
@@ -362,15 +410,15 @@ namespace Shovel
             case Kinds.Hash:
                 return sv.Kind == Kinds.Hash && this.hashValue == sv.hashValue;
             case Kinds.Callable:
-                return sv.Kind == Kinds.Callable && this.CallableValue == sv.CallableValue;
+                return sv.Kind == Kinds.Callable && Equals( this.callableValue, sv.callableValue );
             case Kinds.ReturnAddress:
-                return sv.Kind == Kinds.ReturnAddress && this.ReturnAddressValue == sv.ReturnAddressValue;
+                return sv.Kind == Kinds.ReturnAddress && Equals( this.returnAddressValue, sv.returnAddressValue );
             case Kinds.NamedBlock:
-                return sv.Kind == Kinds.NamedBlock && this.NamedBlockValue == sv.NamedBlockValue;
+                return sv.Kind == Kinds.NamedBlock && Equals( this.namedBlockValue, sv.namedBlockValue );
             case Kinds.Struct:
-                return sv.Kind == Kinds.Struct && this.StructValue == sv.StructValue;
+                return sv.Kind == Kinds.Struct && Equals( this.StructValue, sv.StructValue );
             case Kinds.StructInstance:
-                return sv.Kind == Kinds.StructInstance && this.StructInstanceValue == sv.StructInstanceValue;
+                return sv.Kind == Kinds.StructInstance && Equals( this.structInstanceValue, sv.structInstanceValue );
             default:
                 Utils.Panic ();
                 throw new InvalidOperationException ();
@@ -395,15 +443,15 @@ namespace Shovel
             case Kinds.Hash:
                 return this.hashValue.GetHashCode ();
             case Kinds.Callable:
-                return this.CallableValue.GetHashCode ();
+                return this.callableValue.GetHashCode ();
             case Kinds.ReturnAddress:
-                return this.ReturnAddressValue.GetHashCode ();
+                return this.returnAddressValue.GetHashCode ();
             case Kinds.NamedBlock:
-                return this.NamedBlockValue.GetHashCode ();
+                return this.namedBlockValue.GetHashCode ();
             case Kinds.Struct:
                 return this.StructValue.GetHashCode();
             case Kinds.StructInstance:
-                return this.StructInstanceValue.GetHashCode();
+                return this.structInstanceValue.GetHashCode();
             default:
                 Utils.Panic ();
                 throw new InvalidOperationException ();

--- a/csharp/NShovel/Shovel/Vm/Prim0.cs
+++ b/csharp/NShovel/Shovel/Vm/Prim0.cs
@@ -102,14 +102,14 @@ namespace Shovel.Vm
             var ztruct = args [start].StructValue;
             var result = new StructInstance ();
             result.Struct = ztruct;
-            result.Values = new Value[ztruct.Fields.Length];
+            result.values = new Value[ztruct.Fields.Length];
             var hash = args [start + 1].hashValue;
             var sizeIncrease = 1 + ztruct.Fields.Length;
             api.CellsIncrementHerald (sizeIncrease);
             for (int i = 0; i < ztruct.Fields.Length; i++) {
                 var svKey = Value.Make (ztruct.Fields [i]);
                 if (hash.ContainsKey (svKey)) {
-                    result.Values [i] = hash [svKey];
+                    result.values [i] = hash [svKey];
                 }
             }
             api.CellsIncrementer (sizeIncrease);
@@ -122,12 +122,12 @@ namespace Shovel.Vm
                 api.RaiseShovelError ("First argument must be a struct instance.");
             }
             var result = new HashInstance ();
-            var structInstance = args [start].StructInstanceValue;
+            var structInstance = args [start].structInstanceValue;
             var ztruct = structInstance.Struct;
             var sizeIncrease = 1 + 2 * ztruct.Fields.Length;
             api.CellsIncrementHerald (sizeIncrease);
             for (int i = 0; i < ztruct.Fields.Length; i++) {
-                result [Value.Make (ztruct.Fields [i])] = structInstance.Values [i];
+                result [Value.Make (ztruct.Fields [i])] = structInstance.values [i];
             }
             api.CellsIncrementer (sizeIncrease);
             return Value.Make (result);
@@ -146,9 +146,9 @@ namespace Shovel.Vm
             api.CellsIncrementHerald (sizeIncrease);
             var result = new StructInstance ();
             result.Struct = ztruct;
-            result.Values = new Value[ztruct.Fields.Length];
+            result.values = new Value[ztruct.Fields.Length];
             for (int i = 1; i < length; i++) {
-                result.Values [i - 1] = args [start + i];
+                result.values [i - 1] = args [start + i];
             }
             api.CellsIncrementer (sizeIncrease);
             return Value.Make (result);
@@ -913,17 +913,17 @@ namespace Shovel.Vm
             }
             if (obj.Kind == Value.Kinds.StructInstance) {
                 var cache = vm.GetCurrentCache ();
-                var structInstance = obj.StructInstanceValue;
+                var structInstance = obj.structInstanceValue;
                 var ztruct = structInstance.Struct;
                 if (cache != null) {
                     var info = (Tuple<Struct, int>)cache;
                     if (info.Item1 == ztruct) {
-                        obj = structInstance.Values [info.Item2];
+                        obj = structInstance.values [info.Item2];
                         return true;
                     }
                 }
                 int location = FindLocationInStruct (api, ztruct, index.stringValue);
-                obj = structInstance.Values [location];
+                obj = structInstance.values [location];
                 vm.SetCurrentCache (Tuple.Create (ztruct, location));
             } else if (obj.Kind == Value.Kinds.Hash) {
                 if (!obj.hashValue.ContainsKey (index)) {
@@ -946,17 +946,17 @@ namespace Shovel.Vm
         {
             if (obj.Kind == Value.Kinds.StructInstance) {
                 var cache = vm.GetCurrentCache ();
-                var structInstance = obj.StructInstanceValue;
+                var structInstance = obj.structInstanceValue;
                 var ztruct = structInstance.Struct;
                 if (cache != null) {
                     var info = (Tuple<Struct, int>)cache;
                     if (info.Item1 == ztruct) {
-                        structInstance.Values [info.Item2] = value;
+                        structInstance.values [info.Item2] = value;
                         return true;
                     }
                 }
                 int location = FindLocationInStruct (api, ztruct, index.stringValue);
-                structInstance.Values [location] = value;
+                structInstance.values [location] = value;
                 vm.SetCurrentCache (Tuple.Create (ztruct, location));
             } else if (obj.Kind == Value.Kinds.Hash) {
                 return HashSet(api, ref obj, ref index, ref value);
@@ -1062,12 +1062,12 @@ namespace Shovel.Vm
 
         static Value SetHandlers(VmApi api, Value arrayOrHash, Value getter, Value setter)
         {
-            if (getter.Kind != Value.Kinds.Null && (getter.Kind != Value.Kinds.Callable || getter.CallableValue.Arity != 2))
+            if (getter.Kind != Value.Kinds.Null && (getter.Kind != Value.Kinds.Callable || getter.callableValue.Arity != 2))
             {
                 api.RaiseShovelError("The second parameter (getter) should be a callable with 2 parameters.");
                 throw new InvalidOperationException();
             }
-            if (setter.Kind != Value.Kinds.Null && (setter.Kind != Value.Kinds.Callable || setter.CallableValue.Arity != 3))
+            if (setter.Kind != Value.Kinds.Null && (setter.Kind != Value.Kinds.Callable || setter.callableValue.Arity != 3))
             {
                 api.RaiseShovelError("The third parameter (setter) should be a callable with 3 parameters.");
                 throw new InvalidOperationException();
@@ -1299,7 +1299,7 @@ namespace Shovel.Vm
             if (str.Kind != Value.Kinds.Struct) {
                 api.RaiseShovelError ("Second argument must be a struct.");
             }
-            var result = obj.Kind == Value.Kinds.StructInstance && obj.StructInstanceValue.Struct == str.StructValue;
+            var result = obj.Kind == Value.Kinds.StructInstance && obj.structInstanceValue.Struct == str.StructValue;
             obj.boolValue = result;
             obj.Kind = Value.Kinds.Bool;
         }
@@ -1391,11 +1391,11 @@ namespace Shovel.Vm
                 var sb = new StringBuilder ();
                 sb.Append ("make(");
                 var pieces = new List<string> ();
-                var structInstance = obj.StructInstanceValue;
+                var structInstance = obj.structInstanceValue;
                 var ztruct = structInstance.Struct;
                 pieces.Add (StructAsString (ztruct));
-                for (var i = 0; i < structInstance.Values.Length; i++) {
-                    pieces.Add (ShovelStringRepresentationImpl (api, structInstance.Values [i], visited));
+                for (var i = 0; i < structInstance.values.Length; i++) {
+                    pieces.Add (ShovelStringRepresentationImpl (api, structInstance.values [i], visited));
                 }
                 sb.Append (String.Join (", ", pieces));
                 sb.Append (")");

--- a/csharp/NShovel/Shovel/Vm/Types/NamedBlock.cs
+++ b/csharp/NShovel/Shovel/Vm/Types/NamedBlock.cs
@@ -24,14 +24,13 @@ using System.Collections.Generic;
 
 namespace Shovel.Vm.Types
 {
-	internal class NamedBlock
-	{
-		internal string Name { get; set; }
+    public class NamedBlock
+    {
+        internal string Name { get; set; }
 
-		internal int BlockEnd { get; set; }
+        internal int BlockEnd { get; set; }
 
-		internal VmEnvironment Environment { get; set; }
-	}
-
+        public VmEnvironment Environment { get; internal set; }
+    }
 }
 

--- a/csharp/NShovel/Shovel/Vm/Types/ReturnAddress.cs
+++ b/csharp/NShovel/Shovel/Vm/Types/ReturnAddress.cs
@@ -23,12 +23,11 @@ using System;
 
 namespace Shovel.Vm.Types
 {
-	internal class ReturnAddress
-	{
-		internal VmEnvironment Environment { get; set; }
+    public class ReturnAddress
+    {
+        public VmEnvironment Environment { get; internal set; }
 
-		internal int ProgramCounter { get; set; }
-
-	}
+        internal int ProgramCounter { get; set; }
+    }
 }
 

--- a/csharp/NShovel/Shovel/Vm/Types/VmEnvFrame.cs
+++ b/csharp/NShovel/Shovel/Vm/Types/VmEnvFrame.cs
@@ -22,15 +22,18 @@
 using System;
 using System.Collections.Generic;
 
-namespace Shovel.Vm.Types
+namespace Shovel.Vm
 {
-	internal class VmEnvFrame
-	{
-		internal string[] VarNames { get; set; }
+    public class VmEnvFrame
+    {
+        public IEnumerable<string> Names { get { return VarNamesInternal; } }
+        public IEnumerable<Value> Values { get { return ValuesInernal; } }
 
-		internal Value[] Values { get; set; }
+        internal string[] VarNamesInternal { get; set; }
 
-		internal int? IntroducedAtProgramCounter;
-	}
+        internal Value[] ValuesInernal { get; set; }
+
+        internal int? IntroducedAtProgramCounter;
+    }
 }
 

--- a/csharp/NShovel/Shovel/Vm/Types/VmEnvironment.cs
+++ b/csharp/NShovel/Shovel/Vm/Types/VmEnvironment.cs
@@ -22,13 +22,12 @@
 using System;
 using System.Linq;
 
-namespace Shovel.Vm.Types
+namespace Shovel.Vm
 {
-    internal class VmEnvironment
+    public class VmEnvironment
     {
-        internal VmEnvFrame Frame { get; set; }
-
-        internal VmEnvironment Next { get; set; }
+        public VmEnvFrame Frame { get; internal set; }
+        public VmEnvironment Next { get; internal set; }
     }
 }
 


### PR DESCRIPTION
This just makes certain `internal` members `public` - sufficient for walking the tree of references in terms of reachable values. Plus adds two methods to - `Api.GetUsedStack` and `Api.GetCurrentEnvironment` - which provide roots for the reference tree.

This is one small part of the ongoing `public`-ization process ultimately aimed at making the VM inspectable. This particular part represents minimal changes necessary for collecting garbage in the space of host-allocated handles.
